### PR TITLE
added bsonBatchSize to config

### DIFF
--- a/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
@@ -37,18 +37,21 @@ import org.bson.{Document => _, _}
 import org.mongodb.scala._
 import org.mongodb.scala.connection.NettyStreamFactoryFactory
 
-class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: MongoClient, queueSize: Int) {
+class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: MongoClient, maxMemory: Int) {
+  import Mongo._
+
   val F: ConcurrentEffect[F] = ConcurrentEffect[F]
 
-  private def observableAsStream[A](obs: Observable[A]): Stream[F, A] = {
+  private def observableAsStream[A](obs: Observable[A], queueSize: Long): Stream[F, A] = {
     def run(action: F[Unit]): Unit = F.runAsync(action)(_ => IO.unit).unsafeRunSync
 
     def handler(subVar: MVar[F, Subscription], cb: Option[Either[Throwable, A]] => Unit): Unit = {
       obs.subscribe(new Observer[A] {
         override def onSubscribe(sub: Subscription): Unit = {
           run(subVar.put(sub))
-          sub.request(queueSize.toLong)
+          sub.request(queueSize)
         }
+
         override def onNext(result: A): Unit =
           cb(Some(Right(result)))
 
@@ -69,17 +72,19 @@ class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: Mo
       Stream.eval(F.delay(handler(subVar, { x => run(obsQ.enqueue1(x)) })))
 
     (for {
-      obsQ <- Stream.eval(Queue.boundedNoneTerminated[F, Either[Throwable, A]](queueSize))
+      obsQ <- Stream.eval(Queue.boundedNoneTerminated[F, Either[Throwable, A]](queueSize.toInt))
       subVar <- Stream.eval(MVar[F].empty[Subscription])
       _ <- enqueueObservable(obsQ, subVar)
-      res <- obsQ.dequeueChunk(queueSize).chunks.flatMap( c =>
+      res <- obsQ.dequeue.chunks.flatMap( c =>
         Stream.evalUnChunk(subVar.read.map(_.request(c.size.toLong)).as(c))
       ).rethrow.onFinalize(subVar.take.flatMap(unsubscribe))
     } yield res)
   }
 
+
+
   def databases: Stream[F, Database] =
-    observableAsStream(client.listDatabaseNames).map(Database(_))
+    observableAsStream(client.listDatabaseNames, DefaultQueueSize).map(Database(_))
 
   def databaseExists(database: Database): Stream[F, Boolean] =
     databases.exists(_ === database)
@@ -87,7 +92,7 @@ class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: Mo
   def collections(database: Database): Stream[F, Collection] = for {
     dbExists <- databaseExists(database)
     res <- if (!dbExists) { Stream.empty } else {
-      observableAsStream(client.getDatabase(database.name).listCollectionNames()).map(Collection(database, _))
+      observableAsStream(client.getDatabase(database.name).listCollectionNames(), DefaultQueueSize).map(Collection(database, _))
     }
   } yield res
 
@@ -95,20 +100,45 @@ class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: Mo
     collections(collection.database).exists(_ === collection)
 
   def findAll(collection: Collection): F[Stream[F, BsonValue]] = {
-    def getCollection(mongo: MongoClient) =
-      mongo.getDatabase(collection.database.name).getCollection(collection.name)
-
     collectionExists(collection).compile.last.map(_ getOrElse false)
       .flatMap(exists =>
         if (exists) {
-          F.delay(observableAsStream(getCollection(client).find[BsonValue]()))
+          getQueueSize(collection).map { (qs: Long) =>
+            observableAsStream(getCollection(collection).find[BsonValue](), qs)
+          }
         } else {
           MonadResourceErr.raiseError(ResourceError.pathNotFound(collection.resourcePath))
         })
   }
+
+  def getQueueSize(collection: Collection): F[Long] = {
+    val getStats: F[Document] = F.suspend(singleObservableAsF[F, Document](
+      client.getDatabase(collection.database.name).runCommand[Document](Document(
+        "collStats" -> collection.name,
+        "scale" -> 1
+      ))
+    ))
+
+    val max = if (maxMemory > MaxBsonBatch) MaxBsonBatch else maxMemory.toLong
+
+    getStats map { doc =>
+      val avgObjSize = doc.get("avgObjSize").fold(0)(_.asInt32.getValue)
+      val res = max / avgObjSize.toLong
+      if (res < 1L) 1L else if (res < MaxQueueSize) res else MaxQueueSize
+    }
+  }
+
+  private def getCollection(collection: Collection): MongoCollection[Document] =
+    client.getDatabase(collection.database.name).getCollection(collection.name)
+
 }
 
 object Mongo {
+  val DefaultBsonBatch: Int = 1024 * 128
+  val MaxBsonBatch: Long = 128L * 1024L * 1024L
+  val DefaultQueueSize: Long = 64L
+  val MaxQueueSize: Long = 2048L
+
   def singleObservableAsF[F[_]: Async, A](obs: SingleObservable[A]): F[A] =
     Async[F].async { cb: (Either[Throwable, A] => Unit) =>
       obs.subscribe(new Observer[A] {
@@ -118,7 +148,7 @@ object Mongo {
       })
     }
 
-  def apply[F[_]: ConcurrentEffect: MonadResourceErr](config: MongoConfig, queueSize: Int): F[Disposable[F, Mongo[F]]] = {
+  def apply[F[_]: ConcurrentEffect: MonadResourceErr](config: MongoConfig): F[Disposable[F, Mongo[F]]] = {
     val F = ConcurrentEffect[F]
 
     val mkClient: F[MongoClient] = for {
@@ -141,6 +171,6 @@ object Mongo {
     for {
       client <- mkClient
       _ <- runCommand(client)
-    } yield Disposable(new Mongo[F](client, queueSize), close(client))
+    } yield Disposable(new Mongo[F](client, config.bsonBatchSize.getOrElse(DefaultBsonBatch)), close(client))
   }
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/MongoConfig.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/MongoConfig.scala
@@ -20,18 +20,18 @@ import slamdata.Predef._
 
 import argonaut._, Argonaut._
 
-final case class MongoConfig(connectionString: String)
+final case class MongoConfig(connectionString: String, bsonBatchSize: Option[Int])
 
 object MongoConfig {
   implicit val codecMongoConfig: CodecJson[MongoConfig] =
-    casecodec1(MongoConfig.apply, MongoConfig.unapply)("connectionString")
+    casecodec2(MongoConfig.apply, MongoConfig.unapply)("connectionString", "bsonBatchSize")
 
   private val credentialsRegex = "://[^@+]+@".r
 
   def sanitize(config: Json): Json = config.as[MongoConfig].result match {
     case Left(_) => config
-    case Right(MongoConfig(value)) => {
-      MongoConfig(credentialsRegex.replaceFirstIn(value, "://<REDACTED>:<REDACTED>@")).asJson
+    case Right(MongoConfig(value, mem)) => {
+      MongoConfig(credentialsRegex.replaceFirstIn(value, "://<REDACTED>:<REDACTED>@"), mem).asJson
     }
   }
 }

--- a/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/MongoDataSourceModule.scala
@@ -39,8 +39,6 @@ object MongoDataSourceModule extends LightweightDatasourceModule {
   type Error = InitializationError[Json]
   type ErrorOrResult[F[_]] = Error \/ Result[F]
 
-  val defaultQueueSize: Int = 2048
-
   private def mkError[F[_]](config: Json, msg: String): ErrorOrResult[F] =
     DatasourceError
       .invalidConfiguration[Json, Error](kind, sanitizeConfig(config), NonEmptyList(msg))
@@ -56,7 +54,7 @@ object MongoDataSourceModule extends LightweightDatasourceModule {
       case Left((msg, _)) =>
         mkError(config, msg).pure[F]
       case Right(mongoConfig) => {
-        Mongo(mongoConfig, defaultQueueSize).attempt.map { _ match {
+        Mongo(mongoConfig).attempt.map { _ match {
           case Left(e) => mkError(config, e.getMessage)
           case Right(disposableClient) =>
             disposableClient.map(client => (new MongoDataSource(client): DS[F])).right[Error]

--- a/datasource/src/main/scala/quasar/physical/mongo/decoder.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/decoder.scala
@@ -102,7 +102,6 @@ object decoder {
       case BsonType.MIN_KEY => QMeta
       case BsonType.END_OF_DOCUMENT => QNull
     }
-
     type ArrayCursor = Iterator[BsonValue]
 
     override def getArrayCursor(bson: BsonValue): ArrayCursor = bson match {

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoConfigSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoConfigSpec.scala
@@ -26,24 +26,24 @@ import org.specs2.mutable.Specification
 class MongoConfigSpec extends Specification with ScalaCheck {
   "works for mongodb protocol" >> {
     Json.obj("connectionString" -> jString("mongodb://localhost"))
-      .as[MongoConfig].toEither === Right(MongoConfig("mongodb://localhost"))
+      .as[MongoConfig].toEither === Right(MongoConfig("mongodb://localhost", None))
     Json.obj("connectionString" -> jString("mongodb://user:password@anyhost:2980/database?a=b&c=d"))
-      .as[MongoConfig].toEither === Right(MongoConfig("mongodb://user:password@anyhost:2980/database?a=b&c=d"))
+      .as[MongoConfig].toEither === Right(MongoConfig("mongodb://user:password@anyhost:2980/database?a=b&c=d", None))
   }
 
   "sanitized config hides credentials" >> {
-    val input = Json.obj("connectionString" -> jString("mongodb://user:password@anyhost:2980/database"))
-    val expected = Json.obj("connectionString" -> jString("mongodb://<REDACTED>:<REDACTED>@anyhost:2980/database"))
+    val input = Json.obj("connectionString" -> jString("mongodb://user:password@anyhost:2980/database"), "bsonBatchSize" -> jNumber(128))
+    val expected = Json.obj("connectionString" -> jString("mongodb://<REDACTED>:<REDACTED>@anyhost:2980/database"), "bsonBatchSize" -> jNumber(128))
     MongoConfig.sanitize(input) === expected
   }
   "sanitized config without credentials isn't changed" >> {
-    val input = Json.obj("connectionString" -> jString("mongodb://host:1234/db?foo=bar"))
+    val input = Json.obj("connectionString" -> jString("mongodb://host:1234/db?foo=bar"), "bsonBatchSize" -> jNumber(234))
     MongoConfig.sanitize(input) === input
   }
 
   "json codec" >> {
-    "lawful" >> prop { connectionString: String  =>
-      CodecJson.codecLaw(MongoConfig.codecMongoConfig)(MongoConfig(connectionString))
+    "lawful" >> prop { params: (String, Option[Int])  =>
+      CodecJson.codecLaw(MongoConfig.codecMongoConfig)(MongoConfig(params._1, params._2))
     }
   }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoDataSourceModuleSpec.scala
@@ -33,11 +33,11 @@ class MongoDataSourceModuleSpec extends EffectfulQSpec[IO] {
     MongoDataSourceModule.lightweightDatasource[IO](config).map (_.asCats must beLeft)
   }
   "Using correct config produces Right Disposable" >>* {
-    val config = MongoConfig(MongoSpec.connectionString).asJson
+    val config = MongoConfig(MongoSpec.connectionString, None).asJson
     MongoDataSourceModule.lightweightDatasource[IO](config).map (_.asCats must beRight)
   }
   "Using unreachable config produces Left error" >>* {
-    val config = MongoConfig("mongodb://unreachable").asJson
+    val config = MongoConfig("mongodb://unreachable", None).asJson
     MongoDataSourceModule.lightweightDatasource[IO](config).map (_.asCats must beLeft)
   }
 }

--- a/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/mongo/MongoSpec.scala
@@ -45,10 +45,10 @@ class MongoSpec extends EffectfulQSpec[IO] {
 
   "can't create client from incorrect connection string" >> {
     "for incorrect protocol" >> {
-      Mongo[IO](MongoConfig("http://localhost"), testQueueSize).unsafeRunSync() must throwA[Throwable]
+      Mongo[IO](MongoConfig("http://localhost", Some(128))).unsafeRunSync() must throwA[Throwable]
     }
     "for unreachable config" >> {
-      Mongo[IO](MongoConfig("mongodb://unreachable"), testQueueSize).unsafeRunSync() must throwA[Throwable]
+      Mongo[IO](MongoConfig("mongodb://unreachable", Some(128))).unsafeRunSync() must throwA[Throwable]
     }
 
   }
@@ -130,10 +130,8 @@ object MongoSpec {
 
   lazy val connectionString = Source.fromFile("./datasource/src/test/resources/mongo-connection").mkString.trim
 
-  val testQueueSize: Int = 64
-
   def mkMongo: IO[Disposable[IO, Mongo[IO]]] =
-    Mongo[IO](MongoConfig(connectionString), testQueueSize)
+    Mongo[IO](MongoConfig(connectionString, None))
 
   def incorrectCollections: List[Collection] = {
     val incorrectDbStream =


### PR DESCRIPTION
I'll just leave it here 🙂 

This adds optional field for maximum bsons size that can be put into queue. 

+ I'm not totally sure that this has any sense actually, the size of bsons is much smaller than size of equivalent json, and this basically is magical number that somehow connected with document size and RAM. 
+ This doesn't solve https://app.clubhouse.io/data/story/4265/failure-to-discover-structure-on-mongodb-connector, and I suppose that 2048 queue is OK (in particular for the case described in the issue, I have ~890Mb RAM used before OOM, for other collections everything works fine with 5Gb RAM used) 