### PR TITLE
Rewritten observable -> stream conversion

### DIFF
--- a/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/Mongo.scala
@@ -52,10 +52,8 @@ class Mongo[F[_]: MonadResourceErr : ConcurrentEffect] private[Mongo](client: Mo
           override def onNext(result: A): Unit =
             toIO(as.enqueue1(Some(Right(result)))).unsafeRunSync()
 
-          override def onError(e: Throwable): Unit = {
-            k(Left(e))    // callbacks are idempotent, so this is okay; it will produce the subscription error if we failed to subscribe
+          override def onError(e: Throwable): Unit =
             toIO(as.enqueue1(Some(Left(e)))).unsafeRunSync()
-          }
 
           override def onComplete(): Unit =
             toIO(as.enqueue1(None)).unsafeRunSync()


### PR DESCRIPTION
- Much clearer in terms of control flow (e.g. one `request` call-site as opposed to two; discrete steps managed by `repeat` rather than encoding the loop via indirect data dependencies; etc)
- Output chunk sizes are, ultimately, determined by the rate at which the downstream consumes. Still bounded by the max, but this should allow for better dynamic performance and fairness in the event that the downstream has a natural catch-up mechanism (NB: SST computation is the *opposite* of this, but evaluation has this property)
- Dynamic rechunking has a catch-up mechanism, whereas before, due to the use of `request(c.size)`, any dynamism in the chunking would result in permanent loss of request size, theoretically all the way down to size 1, and thus performance would strictly degrade over large collections
- Backpressure is now applied *within* a chunk. This gives us a number of nice properties, including insulating us from bugs in the mongo driver, but also it allows us to decouple some of the in-fs2 chunk tuning from the in-mongo chunk tuning. In effect, this is what dynamic consumer-side rechunking leverages
- Unsafe running is made considerably more safe by delegating to `unsafeRunSync()`, which handles a number of tricky deadlock edge cases 
- We avoid the need for `MVar`, and its associated statefulness, entirely

I don't think this will have *too* much of an impact on the SST issues we're seeing right now, but it's at least an improvement on what is there now. I think the real gains need to come from something like #43 