### PR TITLE
return None if there are dots in cartesian aliases, wrap name, or CPath

### DIFF
--- a/datasource/src/main/scala/quasar/physical/mongo/MongoExpression.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/MongoExpression.scala
@@ -188,7 +188,7 @@ object MongoExpression {
 
   def cpathToProjection(cpath: CPath): Option[Projection] = {
     cpath.nodes.foldM(Projection()) { (acc, node) => node match {
-      case CPathField(str) => Some(acc +/ key(str))
+      case CPathField(str) if !(str contains ".") => Some(acc +/ key(str))
       case CPathIndex(ix) => Some(acc +/ index(ix))
       case _ => None
     }}

--- a/datasource/src/main/scala/quasar/physical/mongo/interpreter/Cartesian.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/interpreter/Cartesian.scala
@@ -44,6 +44,8 @@ object Cartesian {
 
       val interpretations: Option[List[List[Aggregator]]] =
         cartoucheList.traverse {
+          case (alias, _) if (alias.name contains ".") =>
+            None
           case (alias, (_, instructions)) =>
             val interpreted: Interpretation =
               interpreter.refineInterpretation(alias.name, Interpretation.initial(instructions))

--- a/datasource/src/main/scala/quasar/physical/mongo/interpreter/Wrap.scala
+++ b/datasource/src/main/scala/quasar/physical/mongo/interpreter/Wrap.scala
@@ -26,7 +26,8 @@ object Wrap {
       version: Version,
       name: String)
       : Option[List[Aggregator]] =
-    Some {
+    if (name contains ".") None
+    else Some {
       val tmpKey = uniqueKey.concat("_wrap")
       List(
         Aggregator.project(E.Object(tmpKey -> E.Object(name -> E.key(uniqueKey)))),


### PR DESCRIPTION
[ch5592] [ch5588] 

This is due to pushdown policy where we don't do pushdown if there are any problems. 
I'm going to do object mapping for cartesian here https://app.clubhouse.io/data/story/5612/provide-an-ast-for-mapping-function-in-mongo-ds